### PR TITLE
Cambiar namespace del proyecto

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,11 +5,12 @@ Librería para calcular el Registro Federal de Contribuyentes en México (RFC) -
 
 ## Uso
 
-``` php
+```php
    
-    //Persona físicas
-    use RFC\RfcBuilder;
+    use NainLobato\RFC\RfcBuilder;
     
+    //Persona físicas
+
     $builder = new RfcBuilder();
     
     $rfc = $builder->name('Juan José')
@@ -22,7 +23,6 @@ Librería para calcular el Registro Federal de Contribuyentes en México (RFC) -
     echo $rfc;
     
     //Personas morales
-    use RFC\RfcBuilder;
     
     $builder = new RfcBuilder();
     

--- a/RFC/HomoclaveCalculator.php
+++ b/RFC/HomoclaveCalculator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 class HomoclaveCalculator

--- a/RFC/HomoclavePerson.php
+++ b/RFC/HomoclavePerson.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 interface HomoclavePerson

--- a/RFC/JuristicPerson.php
+++ b/RFC/JuristicPerson.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 class JuristicPerson implements HomoclavePerson

--- a/RFC/JuristicPersonTenDigitCalculator.php
+++ b/RFC/JuristicPersonTenDigitCalculator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 use RFC\SpanishNumbers\SpanishNumbers;

--- a/RFC/NaturalPerson.php
+++ b/RFC/NaturalPerson.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 class NaturalPerson implements HomoclavePerson

--- a/RFC/NaturalPersonTenDigitsCalculator.php
+++ b/RFC/NaturalPersonTenDigitsCalculator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 use InvalidArgumentException;

--- a/RFC/Rfc.php
+++ b/RFC/Rfc.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 class Rfc

--- a/RFC/RfcBuilder.php
+++ b/RFC/RfcBuilder.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 class RfcBuilder

--- a/RFC/RomanNumerals.php
+++ b/RFC/RomanNumerals.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 class RomanNumerals

--- a/RFC/SpanishNumbers/DigitList.php
+++ b/RFC/SpanishNumbers/DigitList.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC\SpanishNumbers;
+namespace NainLobato\RFC\SpanishNumbers;
 
 
 use Exception;

--- a/RFC/SpanishNumbers/FifthPeriod.php
+++ b/RFC/SpanishNumbers/FifthPeriod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC\SpanishNumbers;
+namespace NainLobato\RFC\SpanishNumbers;
 
 
 class FifthPeriod

--- a/RFC/SpanishNumbers/FirstPeriod.php
+++ b/RFC/SpanishNumbers/FirstPeriod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC\SpanishNumbers;
+namespace NainLobato\RFC\SpanishNumbers;
 
 
 class FirstPeriod

--- a/RFC/SpanishNumbers/FourthPeriod.php
+++ b/RFC/SpanishNumbers/FourthPeriod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC\SpanishNumbers;
+namespace NainLobato\RFC\SpanishNumbers;
 
 
 class FourthPeriod

--- a/RFC/SpanishNumbers/SecondPeriod.php
+++ b/RFC/SpanishNumbers/SecondPeriod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC\SpanishNumbers;
+namespace NainLobato\RFC\SpanishNumbers;
 
 
 class SecondPeriod

--- a/RFC/SpanishNumbers/SixthPeriod.php
+++ b/RFC/SpanishNumbers/SixthPeriod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC\SpanishNumbers;
+namespace NainLobato\RFC\SpanishNumbers;
 
 
 class SixthPeriod

--- a/RFC/SpanishNumbers/SpanishNumbers.php
+++ b/RFC/SpanishNumbers/SpanishNumbers.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC\SpanishNumbers;
+namespace NainLobato\RFC\SpanishNumbers;
 
 
 class SpanishNumbers

--- a/RFC/SpanishNumbers/ThirdPeriod.php
+++ b/RFC/SpanishNumbers/ThirdPeriod.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC\SpanishNumbers;
+namespace NainLobato\RFC\SpanishNumbers;
 
 
 class ThirdPeriod

--- a/RFC/StringUtils.php
+++ b/RFC/StringUtils.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 class StringUtils

--- a/RFC/VerificationDigitCalculator.php
+++ b/RFC/VerificationDigitCalculator.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace RFC;
+namespace NainLobato\RFC;
 
 
 class VerificationDigitCalculator

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "autoload": {
       "classmap": [],
       "psr-4": {
-        "RFC\\": "RFC/"
+        "NainLobato\\RFC\\": "RFC/"
       },
       "files": []
     }


### PR DESCRIPTION
Cambio del namespace principal del proyecto de `RFC` a `NainLobato\RFC`.

Este cambio es para procurar la buena práctica de usar `VendorName\ProjectName` y evitar colisiones de espacios de nombres y clases, mencionado en #1 
